### PR TITLE
Creating a video with a timestamp overlay

### DIFF
--- a/FFmpeg.Core/Models/TimestampModel.cs
+++ b/FFmpeg.Core/Models/TimestampModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Core.Models
+{
+    public class TimestampModel
+    {
+        public string InputFile { get; set; }
+        public string OutputFile { get; set; }
+        public int X { get; set; } = 10;
+        public int Y { get; set; } = 10;
+        public int FontSize { get; set; } = 24;
+        public string FontColor { get; set; } = "white";
+    }
+}

--- a/FFmpeg.Infrastructure/Commands/TimestampCommand.cs
+++ b/FFmpeg.Infrastructure/Commands/TimestampCommand.cs
@@ -1,0 +1,34 @@
+﻿using Ffmpeg.Command.Commands;
+using FFmpeg.Core.Models;
+using FFmpeg.Infrastructure.Services;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FFmpeg.Infrastructure.Commands
+{
+        public class TimestampCommand : BaseCommand, ICommand<TimestampModel>
+        {
+            private readonly ICommandBuilder _commandBuilder;
+
+            public TimestampCommand(FFmpegExecutor executor, ICommandBuilder commandBuilder)
+                : base(executor)
+            {
+                _commandBuilder = commandBuilder;
+            }
+
+            public async Task<CommandResult> ExecuteAsync(TimestampModel model)
+            {
+                string drawtextFilter = $"drawtext=text='%{{pts\\:hms}}':x={model.X}:y={model.Y}:fontsize={model.FontSize}:fontcolor={model.FontColor}";
+
+                CommandBuilder = _commandBuilder
+                    .SetInput(model.InputFile)
+                    .AddFilterComplex(drawtextFilter)
+                    .SetOutput(model.OutputFile);
+
+                return await RunAsync();
+            }
+        }
+    }

--- a/FFmpeg.Infrastructure/FFmpeg.Infrastructure.csproj
+++ b/FFmpeg.Infrastructure/FFmpeg.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FFmpeg.Nightly" Version="20200831.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.2" />
   </ItemGroup>
 

--- a/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
+++ b/FFmpeg.Infrastructure/Services/FFmpegServiceFactory.cs
@@ -14,6 +14,8 @@ namespace FFmpeg.Infrastructure.Services
     public interface IFFmpegServiceFactory
     {
         ICommand<WatermarkModel> CreateWatermarkCommand();
+        ICommand<TimestampModel> CreateTimestampCommand();
+
     }
 
     public class FFmpegServiceFactory : IFFmpegServiceFactory
@@ -36,5 +38,10 @@ namespace FFmpeg.Infrastructure.Services
         {
             return new WatermarkCommand(_executor, _commandBuilder);
         }
+        public ICommand<TimestampModel> CreateTimestampCommand()
+        {
+            return new TimestampCommand(_executor, _commandBuilder);
+        }
+
     }
 }

--- a/Ffmpeg.API/FFmpeg.API.csproj
+++ b/Ffmpeg.API/FFmpeg.API.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FFmpeg.Nightly" Version="20200831.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Added support for timestamp overlay on video files.
Integrated FFmpeg with the drawtext filter to display the current timestamp on each frame.
Prepared input/output handling to enable future automation of the process.